### PR TITLE
ENG-63: wire up the edit/delete/regenerate flows to actually work

### DIFF
--- a/electron/main/message-list/base.ts
+++ b/electron/main/message-list/base.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type MessageListInput = {
   role: 'user' | 'assistant' | 'system'
+  id: string
   // TODO: Currently store messages as string, but maybe use rich text implementation
   // text, entities: { offset, length, value } or {{ }} impl could work as well
   message: string

--- a/electron/main/message-list/basic.ts
+++ b/electron/main/message-list/basic.ts
@@ -22,6 +22,12 @@ export class BasicMessageList extends BaseMessageList {
     this.messageList.push(chatMessage)
   }
 
+  delete(messageID: string) {
+    this.messageList = this.messageList.filter(
+      (message) => message.id !== messageID,
+    )
+  }
+
   clear() {
     this.messageList = []
   }

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -9,6 +9,9 @@ contextBridge.exposeInMainWorld('chats', {
   sendMessage: (message) => {
     return ipcRenderer.invoke('chats:sendMessage', message)
   },
+  regenerateMessage: (message) => {
+    return ipcRenderer.invoke('chats:regenerateMessage', message)
+  },
   cleanupSession: ({ modelPath, threadID }) => {
     return ipcRenderer.invoke('chats:cleanupSession', { modelPath, threadID })
   },
@@ -39,11 +42,25 @@ export interface ChatsAPI {
   sendMessage: ({
     message,
     messageID,
+    assistantMessageID,
     threadID,
     promptOptions,
     modelPath,
   }: {
     message: string
+    messageID: string
+    assistantMessageID: string
+    threadID: string
+    promptOptions?: LLamaChatPromptOptions
+    modelPath: string
+  }) => Promise<string>
+
+  regenerateMessage: ({
+    messageID,
+    threadID,
+    promptOptions,
+    modelPath,
+  }: {
     messageID: string
     threadID: string
     promptOptions?: LLamaChatPromptOptions

--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -2,6 +2,7 @@ import {
   LucideBot,
   LucideCopy,
   LucidePencil,
+  LucideRepeat,
   LucideTrash2,
   LucideUser2,
 } from 'lucide-react'
@@ -22,8 +23,8 @@ import {
 import { useCopyToClipboard } from '@/lib/hooks/use-copy-to-clipboard'
 import { useEnterSubmit } from '@/lib/hooks/use-enter-submit'
 import { cn } from '@/lib/utils'
-import { useCurrentThreadID } from '@/providers/chat/manager'
-import { useHistoryManager, useMessage } from '@/providers/history/manager'
+import { useChatManager, useCurrentThreadID } from '@/providers/chat/manager'
+import { useMessage } from '@/providers/history/manager'
 
 import { CodeBlock } from './codeblock'
 import { MemoizedReactMarkdown } from './markdown'
@@ -35,7 +36,7 @@ export function ChatMessage({
   messageID: string
   onHeightChange: () => void
 }) {
-  const historyManager = useHistoryManager()
+  const chatManager = useChatManager()
   const possibleMessage = useMessage(messageID)
   const currentThreadID = useCurrentThreadID()
 
@@ -92,7 +93,7 @@ export function ChatMessage({
                 if (formData.has('message')) {
                   const message = formData.get('message') as string
                   if (message.trim().length > 0) {
-                    historyManager.editMessage({
+                    chatManager.editMessage({
                       threadID: currentThreadID,
                       messageID: messageID,
                       contents: message,
@@ -201,7 +202,7 @@ export function ChatMessage({
                   variant="iconButton"
                   className="text-muted-foreground hover:text-destructive h-4 p-0"
                   onClick={() =>
-                    historyManager.deleteMessage({
+                    chatManager.deleteMessage({
                       threadID: currentThreadID,
                       messageID,
                     })
@@ -224,6 +225,22 @@ export function ChatMessage({
                   <LucideCopy size={14} />
                 </Button>
               </MessageControlTooltip>
+              {message.role === 'assistant' ? (
+                <MessageControlTooltip description="Regenerate">
+                  <Button
+                    variant="iconButton"
+                    className="text-muted-foreground hidden h-4 p-0 group-last:block"
+                    onClick={() => {
+                      chatManager.regenerateMessage({
+                        threadID: currentThreadID,
+                        messageID,
+                      })
+                    }}
+                  >
+                    <LucideRepeat size={14} />
+                  </Button>
+                </MessageControlTooltip>
+              ) : null}
             </TooltipProvider>
           )}
         </div>


### PR DESCRIPTION
Am shuttling the data back and forth as necessary to enable this behavior, and forcing a sync using Ny's history helper helps with edits/deletes.

https://github.com/dynaboard/ai-assistants/assets/228341/10d4c9b6-b23b-46f1-a921-6a061266e1b5

