### PR TITLE
ENG-66: ensure app can run when built

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+shamefully-hoist=true

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -4,7 +4,7 @@
 {
   appId: 'com.dynaboard.ai-studio',
   productName: 'Dynaboard AI Studio',
-  asar: true,
+  asar: false,
   directories: {
     output: 'release/${version}',
   },
@@ -27,10 +27,5 @@
     perMachine: false,
     allowToChangeInstallationDirectory: true,
     deleteAppDataOnUninstall: false,
-  },
-  publish: {
-    provider: 'generic',
-    channel: 'latest',
-    url: 'https://github.com/electron-vite/electron-vite-react/releases/download/v0.9.9/',
   },
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,10 @@
 {
   "name": "dynaboard-ai-studio",
+  "author": {
+    "name": "Dynaboard",
+    "email": "ai-studio@dynaboard.com"
+  },
+  "description": "Dynaboard AI Studio",
   "version": "1.0.0",
   "main": "dist-electron/main/index.js",
   "private": true,

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,12 +1,12 @@
 import { Suspense } from 'react'
-import { createBrowserRouter, redirect } from 'react-router-dom'
+import { createHashRouter, redirect } from 'react-router-dom'
 
 import App from '@/App'
 import { ChatThread } from '@/routes/chats/ChatThread'
 import { ChatsIndex } from '@/routes/chats/Index'
 import { ModelsPage } from '@/routes/Models'
 
-export const router = createBrowserRouter([
+export const router = createHashRouter([
   {
     path: '/',
     element: (


### PR DESCRIPTION
`pnpm build` should create the assets locally. You can look inside `./release` for those artifacts (zip and dmg).

Issue was that the way that pnpm manages node_modules doesnt jive with how electron expects node_modules to be. Please run `pnpm i` before building.

https://github.com/dynaboard/ai-studio/assets/228341/1513b2e4-3abf-4a67-98c3-245a80c97e07

