### PR TITLE
Fix all the possible states in chat window

### DIFF
--- a/src/components/chat-window.tsx
+++ b/src/components/chat-window.tsx
@@ -1,4 +1,4 @@
-import { SendHorizonal } from 'lucide-react'
+import { LucideLoader2, SendHorizonal } from 'lucide-react'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Textarea from 'react-textarea-autosize'
 import { useValue } from 'signia-react'
@@ -27,9 +27,11 @@ import { Header } from './header'
 
 function StatusIndicatorText({
   text,
+  spinner,
   className,
 }: {
   text: string
+  spinner?: boolean
   className?: string
 }) {
   return (
@@ -39,6 +41,9 @@ function StatusIndicatorText({
         className,
       )}
     >
+      {spinner && (
+        <LucideLoader2 className="mr-2 h-4 w-4 animate-spin text-muted-foreground" />
+      )}
       {text}
     </span>
   )
@@ -241,8 +246,9 @@ export function ChatWindow({ id }: { id?: string }) {
             <div className="flex h-full flex-col items-center justify-center gap-2">
               {runningEmbeddings && selectedFile ? (
                 <StatusIndicatorText
-                  text={`Processing ${selectedFile.name}...`}
+                  text={`Processing ${selectedFile.name}`}
                   className="cursor-progress"
+                  spinner
                 />
               ) : (
                 <StatusIndicatorText text={`Chat with ${fileName}`} />


### PR DESCRIPTION
Default 
<img width="1217" alt="image" src="https://github.com/dynaboard/ai-studio/assets/1021101/97661dd6-eb68-440e-9a86-44340c683a07">

After dropping the file
<img width="1213" alt="image" src="https://github.com/dynaboard/ai-studio/assets/1021101/8dd7fdc0-0839-4ea3-ab35-391cf78234cf">

When the file is loaded
<img width="1216" alt="image" src="https://github.com/dynaboard/ai-studio/assets/1021101/b2859144-6be2-4dfc-9cd8-82ec8affde1e">

Normal chat without filename
<img width="1216" alt="image" src="https://github.com/dynaboard/ai-studio/assets/1021101/b556a425-8a33-4bff-a27e-9eade885e26a">
