### PR TITLE
Missing notarize step for build

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -20,6 +20,7 @@ nsis:
   shortcutName: ${productName}
   uninstallDisplayName: ${productName}
   createDesktopShortcut: always
+afterSign: scripts/notarize.js
 mac:
   entitlementsInherit: build/entitlements.mac.plist
   extendInfo:
@@ -27,7 +28,7 @@ mac:
     - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
     - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
-  notarize: true
+  notarize: false
 dmg:
   artifactName: ${name}-${version}.${ext}
 linux:


### PR DESCRIPTION
Notarize requires valid Apple certs, but you can skip if you want a local build by setting `CSC_IDENTITY_AUTO_DISCOVERY=false` in your env vars.