### PR TITLE
Multi-tool calling

### DIFF
--- a/src/main/managers/tools.ts
+++ b/src/main/managers/tools.ts
@@ -8,7 +8,7 @@ import {
   ElectronLlamaServerManager,
 } from '@/managers/llama-server'
 
-import toolGrammar from '../../../resources/grammars/tools.gbnf?asset'
+import multiToolGrammar from '../../../resources/grammars/multi-tool.gbnf?asset'
 import { Image, SearchApi } from '../tools/search'
 
 const SERVER_ID = 'TOOL_SERVER'
@@ -31,12 +31,12 @@ export class ElectronToolManager {
   async getTool(prompt: string, tools: Record<string, unknown>[]) {
     await this.serverReady
 
-    const systemPrompt = `You are an AI assistant. You call tools on behalf of a user. Tools have parameters. You must extract those parameters from the user's request. You have access to the following tools, and only these tools:
+    const systemPrompt = `[INST]You are an AI assistant. You call tools on behalf of a user. Tools have parameters. You must extract those parameters from the user's request. You have access to the following tools, and only these tools:
     ${JSON.stringify(tools)}
 
     Never call a tool that does not exist. If you cannot find a tool to call, respond with: { "id": "invalid-tool", parameters: [] }`
 
-    const finalPrompt = `${systemPrompt}\n\nUSER: ${prompt}}\nASSISTANT:`
+    const finalPrompt = `${systemPrompt}\n\nUSER: ${prompt}}[/INST]\nASSISTANT:`
 
     const paramDefaults = {
       stream: true,
@@ -45,7 +45,7 @@ export class ElectronToolManager {
       stop: ['</s>', 'USER:', 'ASSISTANT:'],
     }
 
-    const grammar = readFileSync(toolGrammar, 'utf-8')
+    const grammar = readFileSync(multiToolGrammar, 'utf-8')
 
     const params: CompletionParams = {
       temperature: 0.3,

--- a/src/main/managers/tools.ts
+++ b/src/main/managers/tools.ts
@@ -94,6 +94,20 @@ export class ElectronToolManager {
     return results
   }
 
+  async crawlWebsites(query: string, limit: number) {
+    const searchApi = new SearchApi()
+
+    const results: unknown[] = []
+    const websites = searchApi.text({
+      keywords: query,
+      limit,
+    })
+    for await (const website of websites) {
+      results.push(website)
+    }
+    return results
+  }
+
   addClientEventHandlers() {
     ipcMain.handle(ToolChannel.GetTool, async (_, { prompt, tools }) => {
       return await this.getTool(prompt, tools)
@@ -107,6 +121,9 @@ export class ElectronToolManager {
     )
     ipcMain.handle(ToolChannel.CrawlImages, async (_, { query, limit }) => {
       return await this.crawlImages(query, limit)
+    })
+    ipcMain.handle(ToolChannel.CrawlWebsites, async (_, { query, limit }) => {
+      return await this.crawlWebsites(query, limit)
     })
   }
 }

--- a/src/main/tools/search.ts
+++ b/src/main/tools/search.ts
@@ -41,6 +41,12 @@ export type Image = {
   source: string
 }
 
+export type Text = {
+  title: string
+  href: string
+  body: string
+}
+
 // Simulating the main class
 export class SearchApi {
   private logger: Console
@@ -156,16 +162,19 @@ export class SearchApi {
     }
   }
 
-  async *text(
-    keywords: string,
-    region: string = 'wt-wt',
-    safesearch: string = 'moderate',
-    timelimit: string | null = null,
-  ): AsyncGenerator<{
-    title: string
-    href: string
-    body: string
-  }> {
+  async *text({
+    keywords,
+    region = 'wt-wt',
+    safesearch = 'moderate',
+    timelimit = null,
+    limit = 5,
+  }: {
+    keywords: string
+    region?: string
+    safesearch?: string
+    timelimit?: string | null
+    limit?: number
+  }): AsyncGenerator<Text> {
     if (!keywords) {
       throw new Error('Keywords are mandatory')
     }
@@ -218,7 +227,7 @@ export class SearchApi {
         }
 
         let resultExists = false
-        for (const row of pageData.slice(0, 2)) {
+        for (const row of pageData.slice(0, limit)) {
           const href = row.u
           if (
             href &&

--- a/src/preload/events.ts
+++ b/src/preload/events.ts
@@ -26,4 +26,5 @@ export enum ToolChannel {
   GetTool = 'tools:getTool',
   Fetch = 'tools:fetch',
   CrawlImages = 'tools:crawlImages',
+  CrawlWebsites = 'tools.crawlWebsites',
 }

--- a/src/preload/tools.ts
+++ b/src/preload/tools.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron'
 
-import { Image } from '../main/tools/search'
+import { Image, Text } from '../main/tools/search'
 import { ToolChannel } from './events'
 
 contextBridge.exposeInMainWorld('tools', {
@@ -25,6 +25,13 @@ contextBridge.exposeInMainWorld('tools', {
       limit,
     })
   },
+
+  async crawlWebsites(query: string, limit: number) {
+    return ipcRenderer.invoke(ToolChannel.CrawlWebsites, {
+      query,
+      limit,
+    })
+  },
 } satisfies ToolsAPI)
 
 export interface ToolsAPI {
@@ -37,6 +44,7 @@ export interface ToolsAPI {
   ) => Promise<string | Record<string, unknown>>
 
   crawlImages: (query: string, limit: number) => Promise<Image[]>
+  crawlWebsites: (query: string, limit: number) => Promise<Text[]>
 }
 
 declare global {

--- a/src/renderer/components/chat-message.tsx
+++ b/src/renderer/components/chat-message.tsx
@@ -5,6 +5,7 @@ import {
   LucideRepeat,
   LucideTrash2,
   LucideUser2,
+  LucideWrench,
 } from 'lucide-react'
 import React, { useRef, useState } from 'react'
 import ReactDOM from 'react-dom'
@@ -25,6 +26,7 @@ import { useEnterSubmit } from '@/lib/hooks/use-enter-submit'
 import { cn } from '@/lib/utils'
 import { useChatManager, useCurrentThreadID } from '@/providers/chat/manager'
 import { useMessage } from '@/providers/history/manager'
+import { useAllTools } from '@/providers/tools/manager'
 
 import { CodeBlock } from './codeblock'
 import { MemoizedReactMarkdown } from './markdown'
@@ -77,9 +79,11 @@ export function ChatMessage({
         <span className="bg-secondary text-xs text-muted-foreground">
           {message.role === 'user' ? (
             <LucideUser2 size={18} />
-          ) : (
+          ) : message.role === 'assistant' ? (
             <LucideBot size={18} />
-          )}
+          ) : message.role === 'tool' ? (
+            <LucideWrench size={18} />
+          ) : null}
         </span>
       </div>
       <div className="grid grid-rows-[min-content,_16px]">
@@ -121,7 +125,8 @@ export function ChatMessage({
                 spellCheck={false}
               />
             </form>
-          ) : message.role === 'assistant' && message.state === 'pending' ? (
+          ) : (message.role === 'assistant' || message.role === 'tool') &&
+            message.state === 'pending' ? (
             <p className="mb-2 inline-block text-sm leading-relaxed text-gray-900 after:inline-block after:w-0 after:animate-ellipsis after:overflow-hidden after:align-bottom after:content-['…'] last:mb-0">
               Thinking
             </p>
@@ -129,7 +134,7 @@ export function ChatMessage({
             <MemoizedReactMarkdown
               className={cn(
                 'markdown max-w-none text-sm',
-                message.role === 'assistant'
+                message.role === 'assistant' || message.role === 'tool'
                   ? 'prose prose-p:text-gray-900 prose-pre:bg-transparent prose-pre:p-0 prose-ol:text-gray-900 prose-ul:text-gray-900 prose-li:text-gray-900'
                   : '',
               )}
@@ -177,88 +182,95 @@ export function ChatMessage({
                 },
               }}
             >
-              {message.role === 'assistant' && message.state === 'pending'
+              {(message.role === 'assistant' || message.role === 'tool') &&
+              message.state === 'pending'
                 ? ''
                 : message.message || ' '}
             </MemoizedReactMarkdown>
           )}
         </div>
-        <div
-          className={cn(
-            'flex gap-2 opacity-0',
-            editing ? 'opacity-100' : 'group-hover:opacity-100',
-          )}
-        >
+        <div className="flex items-center gap-2">
           {editing ? (
             <span className="text-xs text-muted-foreground">
               Submit new message using Enter
             </span>
           ) : (
-            <TooltipProvider>
-              <MessageControlTooltip description="Edit">
-                <Button
-                  variant="iconButton"
-                  className="h-4 p-0 text-muted-foreground"
-                  onClick={() => {
-                    // we can avoid a useEffect
-                    ReactDOM.flushSync(() => {
-                      setEditing(true)
-                    })
-
-                    if (inputRef.current) {
-                      inputRef.current.value = message.message
-                      inputRef.current?.focus()
-                    }
-                  }}
-                >
-                  <LucidePencil size={14} />
-                </Button>
-              </MessageControlTooltip>
-              <MessageControlTooltip description="Delete">
-                <Button
-                  variant="iconButton"
-                  className="h-4 p-0 text-muted-foreground hover:text-destructive"
-                  onClick={() =>
-                    chatManager.deleteMessage({
-                      threadID: currentThreadID,
-                      messageID,
-                    })
-                  }
-                >
-                  <LucideTrash2 size={14} />
-                </Button>
-              </MessageControlTooltip>
-              <MessageControlTooltip
-                open={isCopied ? true : undefined} // intentionally undefined
-                description={isCopied ? 'Copied' : 'Copy'}
-              >
-                <Button
-                  variant="iconButton"
-                  className="h-4 p-0 text-muted-foreground"
-                  onClick={() => {
-                    copyToClipboard(message.message)
-                  }}
-                >
-                  <LucideCopy size={14} />
-                </Button>
-              </MessageControlTooltip>
-              {message.role === 'assistant' ? (
-                <MessageControlTooltip description="Regenerate">
-                  <Button
-                    variant="iconButton"
-                    className="hidden h-4 p-0 text-muted-foreground group-last:block"
-                    onClick={() => {
-                      chatManager.regenerateMessage({
-                        threadID: currentThreadID,
-                        messageID,
-                      })
-                    }}
-                  >
-                    <LucideRepeat size={14} />
-                  </Button>
-                </MessageControlTooltip>
+            <>
+              {message.toolID && message.role === 'tool' ? (
+                <div className="text-xs text-muted-foreground">
+                  <ToolName toolID={message.toolID} />
+                </div>
               ) : null}
-            </TooltipProvider>
+              <div
+                className={cn('flex gap-2 opacity-0 group-hover:opacity-100')}
+              >
+                <TooltipProvider>
+                  <MessageControlTooltip description="Edit">
+                    <Button
+                      variant="iconButton"
+                      className="h-4 p-0 text-muted-foreground"
+                      onClick={() => {
+                        // we can avoid a useEffect
+                        ReactDOM.flushSync(() => {
+                          setEditing(true)
+                        })
+
+                        if (inputRef.current) {
+                          inputRef.current.value = message.message
+                          inputRef.current?.focus()
+                        }
+                      }}
+                    >
+                      <LucidePencil size={14} />
+                    </Button>
+                  </MessageControlTooltip>
+                  <MessageControlTooltip description="Delete">
+                    <Button
+                      variant="iconButton"
+                      className="h-4 p-0 text-muted-foreground hover:text-destructive"
+                      onClick={() =>
+                        chatManager.deleteMessage({
+                          threadID: currentThreadID,
+                          messageID,
+                        })
+                      }
+                    >
+                      <LucideTrash2 size={14} />
+                    </Button>
+                  </MessageControlTooltip>
+                  <MessageControlTooltip
+                    open={isCopied ? true : undefined} // intentionally undefined
+                    description={isCopied ? 'Copied' : 'Copy'}
+                  >
+                    <Button
+                      variant="iconButton"
+                      className="h-4 p-0 text-muted-foreground"
+                      onClick={() => {
+                        copyToClipboard(message.message)
+                      }}
+                    >
+                      <LucideCopy size={14} />
+                    </Button>
+                  </MessageControlTooltip>
+                  {message.role === 'assistant' ? (
+                    <MessageControlTooltip description="Regenerate">
+                      <Button
+                        variant="iconButton"
+                        className="hidden h-4 p-0 text-muted-foreground group-last:block"
+                        onClick={() => {
+                          chatManager.regenerateMessage({
+                            threadID: currentThreadID,
+                            messageID,
+                          })
+                        }}
+                      >
+                        <LucideRepeat size={14} />
+                      </Button>
+                    </MessageControlTooltip>
+                  ) : null}
+                </TooltipProvider>
+              </div>
+            </>
           )}
         </div>
       </div>
@@ -283,4 +295,10 @@ function MessageControlTooltip({
       </TooltipContent>
     </Tooltip>
   )
+}
+
+function ToolName({ toolID }: { toolID: string }) {
+  const tools = useAllTools()
+
+  return tools.find((tool) => tool.id === toolID)?.name || toolID
 }

--- a/src/renderer/components/configuration.tsx
+++ b/src/renderer/components/configuration.tsx
@@ -7,6 +7,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
+import { useCurrentThreadID } from '@/providers/chat/manager'
 import {
   useActiveTools,
   useAllTools,
@@ -18,8 +19,9 @@ import { TemperatureSelector } from './parameters/temperature'
 import { TopPSelector } from './parameters/top-p'
 
 export function ParametersConfig({ fileName }: { fileName?: string }) {
+  const threadID = useCurrentThreadID()
   const allTools = useAllTools()
-  const activeTools = useActiveTools()
+  const activeTools = useActiveTools(threadID)
   const toolManager = useToolManager()
 
   return (
@@ -73,12 +75,15 @@ export function ParametersConfig({ fileName }: { fileName?: string }) {
                       <div className="flex gap-2">
                         <Checkbox
                           id={`tool-${tool.id}`}
-                          defaultChecked={activeTools.includes(tool)}
+                          // defaultChecked={activeTools.includes(tool)}
+                          checked={activeTools.includes(tool)}
                           onCheckedChange={(checked: boolean) => {
-                            if (checked) {
-                              toolManager.enableTool(tool.id)
-                            } else {
-                              toolManager.disableTool(tool.id)
+                            if (threadID) {
+                              if (checked) {
+                                toolManager.enableTool(threadID, tool.id)
+                              } else {
+                                toolManager.disableTool(threadID, tool.id)
+                              }
                             }
                           }}
                         />

--- a/src/renderer/providers/chat/types.ts
+++ b/src/renderer/providers/chat/types.ts
@@ -2,6 +2,7 @@ export type Message = {
   role: 'user' | 'system' | 'assistant' | 'tool'
   message: string
   id: string
-  state: 'pending' | 'sent' | 'running-tools'
+  state: 'pending' | 'sent'
   date: string
+  toolID?: string
 }

--- a/src/renderer/providers/chat/types.ts
+++ b/src/renderer/providers/chat/types.ts
@@ -1,7 +1,7 @@
 export type Message = {
-  role: 'user' | 'system' | 'assistant'
+  role: 'user' | 'system' | 'assistant' | 'tool'
   message: string
   id: string
-  state: 'pending' | 'sent'
+  state: 'pending' | 'sent' | 'running-tools'
   date: string
 }

--- a/src/renderer/providers/history/manager.ts
+++ b/src/renderer/providers/history/manager.ts
@@ -258,6 +258,27 @@ export class HistoryManager {
     })
   }
 
+  updateThreadTools(threadID: string, toolIDs: string[]) {
+    this._state.update((state) => {
+      const threads = state.threads.map((thread) => {
+        if (thread.id === threadID && thread.activeToolIDs !== toolIDs) {
+          return {
+            ...thread,
+            activeToolIDs: toolIDs,
+          } as Thread
+        }
+        return thread
+      })
+
+      localStorage.setItem('threads', JSON.stringify(threads))
+
+      return {
+        ...state,
+        threads,
+      }
+    })
+  }
+
   addMessage({ threadID, message }: { threadID: string; message: Message }) {
     this._state.update((state) => {
       const threads = state.threads.map((thread) => {
@@ -458,6 +479,13 @@ export function useThreadMessages(threadID?: string) {
 export function useThreadFilePath(threadID?: string) {
   const thread = useThread(threadID)
   return useValue('threadFilePath', () => thread?.filePath ?? null, [thread])
+}
+
+export function useThreadActiveToolIDs(threadID?: string) {
+  const thread = useThread(threadID)
+  return useValue('threadFilePath', () => thread?.activeToolIDs ?? null, [
+    thread,
+  ])
 }
 
 export function useMessage(messageID: string) {

--- a/src/renderer/providers/history/manager.ts
+++ b/src/renderer/providers/history/manager.ts
@@ -320,6 +320,10 @@ export class HistoryManager {
     })
   }
 
+  getMessage(messageID: string) {
+    return this.state.messages.get(messageID)
+  }
+
   editMessage({
     threadID,
     messageID,

--- a/src/renderer/providers/history/types.ts
+++ b/src/renderer/providers/history/types.ts
@@ -10,4 +10,9 @@ export type Thread = {
   temperature: number
   systemPrompt: string
   filePath?: string
+  toolCalls?: {
+    toolID: string
+    messageID: string
+    parameters: Record<string, unknown>[]
+  }[]
 }

--- a/src/renderer/providers/history/types.ts
+++ b/src/renderer/providers/history/types.ts
@@ -10,6 +10,7 @@ export type Thread = {
   temperature: number
   systemPrompt: string
   filePath?: string
+  activeToolIDs?: string[]
   toolCalls?: {
     toolID: string
     messageID: string

--- a/src/renderer/tools/base.ts
+++ b/src/renderer/tools/base.ts
@@ -16,6 +16,7 @@ export type RunContext = {
   assistantMessageID: string
   threadID: string
   modelPath: string
+  previousToolCalls: { id: string; result: unknown }[]
   promptOptions?: PromptOptions
 }
 

--- a/src/renderer/tools/search-results.ts
+++ b/src/renderer/tools/search-results.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod'
+
+import { BaseTool, RunContext, ToolParameter } from '@/tools/base'
+
+export default class SearchResultsTool extends BaseTool {
+  name = 'Search Results'
+  description = 'Search the web for websites related to your query.'
+  requiredModels = ['Mistral 7B Instruct v0.1']
+
+  parameters: ToolParameter[] = [
+    {
+      name: 'query',
+      description: 'The search query for the websites you are looking for.',
+      type: 'string',
+    },
+    {
+      name: 'numberOfSites',
+      description: 'The number of sites you want to return. Default 5.',
+      type: 'number',
+    },
+  ]
+
+  async run(_ctx: RunContext, query: unknown, numberOfSites: unknown) {
+    const { value: queryInput } = z
+      .object({
+        name: z.literal('query'),
+        value: z.string(),
+      })
+      .parse(query)
+
+    const { value: limitInput } = z
+      .object({
+        name: z.literal('numberOfSites'),
+        value: z.coerce.number(),
+      })
+      .parse(numberOfSites)
+
+    const results = await window.tools.crawlWebsites(queryInput, limitInput)
+    return results
+      .map((result) => {
+        return `${result.title} (${result.href})
+
+${result.body}\n`
+      })
+      .join('\n')
+  }
+}

--- a/src/shared/message-list/base.ts
+++ b/src/shared/message-list/base.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ChatMessage = {
-  role: 'user' | 'assistant' | 'system'
+  role: 'user' | 'assistant' | 'system' | 'tool'
   id: string
   // TODO: Currently store messages as string, but maybe use rich text implementation
   // text, entities: { offset, length, value } or {{ }} impl could work as well


### PR DESCRIPTION
Updates to allow multi-tool calling. Lets the LLM try and figure out which tools to call in which order. I tested out multiple prompts, but the initial prompt we settled on does well as long as the grammar is set to the multitool version (list root instead of object root). Some of the changes:
- Call tools serially, in-order. Pass results of previous calls within the context into the NEXT tool call (lets the following tools look up previous tool info)
- Active tools are stored on threads themselves, so you can turn on and off tools based on what you want (and persists across loads)
- Tool-based messages are tagged with the tool ID used. We display the tool name based on this (lets you know whats the tool and whats the LLM)
- Also storing tool calls themselves on the thread, so we can look it up down the line (tool ID, message ID, and specific parameters the tool is called with).
- Added a web crawling tool based on Ny's image search (since he implemented it, just wanted to expose it).

https://github.com/dynaboard/ai-studio/assets/228341/430b2124-c413-477e-af27-476cf911dc34

