### PR TITLE
Toast and QoL improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "remark-math": "^5.1.1",
     "signia": "^0.1.4",
     "signia-react": "^0.1.4",
+    "sonner": "^1.2.4",
     "suspend-react": "^0.1.3",
     "tailwind-merge": "^2.0.0",
     "tailwindcss": "^3.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ dependencies:
   signia-react:
     specifier: ^0.1.4
     version: 0.1.4(react@18.2.0)
+  sonner:
+    specifier: ^1.2.4
+    version: 1.2.4(react-dom@18.2.0)(react@18.2.0)
   suspend-react:
     specifier: ^0.1.3
     version: 0.1.3(react@18.2.0)
@@ -8462,6 +8465,16 @@ packages:
       ip: 2.0.0
       smart-buffer: 4.2.0
     dev: true
+
+  /sonner@1.2.4(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-WGLP2QQnomgewaCTsK7YWiLcy5n1Yj83vsL5cP4zHMmpSkmFsCYTpQKhlXJrPE5kzjwbqCkCFXcOpbKc4vaUaA==}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
 
   /source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -112,6 +112,9 @@ async function createWindow() {
   win.on('blur', windowInactiveListener)
   win.on('show', windowActiveListener)
   win.on('focus', windowActiveListener)
+  win.on('closed', () => {
+    win = null
+  })
 
   // Apply electron-updater
   update(win)

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Outlet, useLoaderData, useNavigate } from 'react-router-dom'
+import { Toaster } from 'sonner'
 import { suspend } from 'suspend-react'
 
 import { Setup } from '@/components/setup'
@@ -69,6 +70,8 @@ export function App() {
             <DownloadStatus />
           </div>
         </div>
+
+        <Toaster />
       </ToolManagerProvider>
     </ChatManagerProvider>
   )

--- a/src/renderer/components/chat-message.tsx
+++ b/src/renderer/components/chat-message.tsx
@@ -24,7 +24,11 @@ import {
 import { useCopyToClipboard } from '@/lib/hooks/use-copy-to-clipboard'
 import { useEnterSubmit } from '@/lib/hooks/use-enter-submit'
 import { cn } from '@/lib/utils'
-import { useChatManager, useCurrentThreadID } from '@/providers/chat/manager'
+import {
+  useChatManager,
+  useCurrentThreadID,
+  useIsCurrentThreadGenerating,
+} from '@/providers/chat/manager'
 import { useMessage } from '@/providers/history/manager'
 import { useAllTools } from '@/providers/tools/manager'
 
@@ -41,6 +45,8 @@ export function ChatMessage({
   const chatManager = useChatManager()
   const possibleMessage = useMessage(messageID)
   const currentThreadID = useCurrentThreadID()
+  const isCurrentThreadGenerating =
+    useIsCurrentThreadGenerating(currentThreadID)
 
   const { ref } = useResizeObserver({
     onResize() {
@@ -126,7 +132,9 @@ export function ChatMessage({
               />
             </form>
           ) : (message.role === 'assistant' || message.role === 'tool') &&
-            message.state === 'pending' ? (
+            message.state === 'pending' &&
+            // Safety check from the actual message's process
+            isCurrentThreadGenerating ? (
             <p className="mb-2 inline-block text-sm leading-relaxed text-gray-900 after:inline-block after:w-0 after:animate-ellipsis after:overflow-hidden after:align-bottom after:content-['…'] last:mb-0">
               Thinking
             </p>

--- a/src/renderer/components/chat-sidebar.tsx
+++ b/src/renderer/components/chat-sidebar.tsx
@@ -25,7 +25,10 @@ import {
   useChatManager,
   useCurrentThreadID,
 } from '@/providers/chat/manager'
-import { useHistoryManager } from '@/providers/history/manager'
+import {
+  useHistoryManager,
+  useThreadMessages,
+} from '@/providers/history/manager'
 import { Thread } from '@/providers/history/types'
 
 export function ThreadsSidebar() {
@@ -120,11 +123,13 @@ function Node({ node, style, dragHandle }: NodeRendererProps<Thread>) {
   const currentThreadID = useCurrentThreadID()
   const navigate = useNavigate()
 
-  const matches = useMatches()
-
-  const active = matches[matches.length - 1]?.id === 'thread'
-
   const [showDeleteDialog, setShowDeleteDialog] = React.useState(false)
+
+  const messages = useThreadMessages(currentThreadID)
+  const haveMessages = messages.length > 0
+
+  const matches = useMatches()
+  const active = matches[matches.length - 1]?.id === 'thread'
 
   const deleteThread = async (event: React.MouseEvent) => {
     event.preventDefault()
@@ -190,7 +195,13 @@ function Node({ node, style, dragHandle }: NodeRendererProps<Thread>) {
               <Button
                 variant="iconButton"
                 className="hidden h-full w-0 p-0 hover:text-destructive group-hover/node:block group-hover/node:w-auto"
-                onClick={() => setShowDeleteDialog(true)}
+                onClick={async (e) => {
+                  if (!haveMessages) {
+                    await deleteThread(e)
+                  } else {
+                    setShowDeleteDialog(true)
+                  }
+                }}
               >
                 <LucideTrash size={14} />
               </Button>

--- a/src/renderer/components/chat-window.tsx
+++ b/src/renderer/components/chat-window.tsx
@@ -88,6 +88,7 @@ export function ChatWindow({ id }: { id?: string }) {
   const [userScrolled, setUserScrolled] = useState(false)
   const [runningEmbeddings, setRunningEmbeddings] = useState(false)
   const [shouldRefocusTextarea, setShouldRefocusTextarea] = useState(false)
+  const [hasMessage, setHasMessage] = useState(false)
 
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
   const [base64Image, setBase64Image] = useState<string | null>(null)
@@ -180,7 +181,7 @@ export function ChatWindow({ id }: { id?: string }) {
     [userScrolled],
   )
 
-  const handleMessage = useCallback(
+  const handleFormSubmit = useCallback(
     (event: React.FormEvent<HTMLFormElement>) => {
       event.preventDefault()
       const data = new FormData(event.currentTarget)
@@ -211,6 +212,18 @@ export function ChatWindow({ id }: { id?: string }) {
       selectedFile,
     ],
   )
+
+  const handleFormChange = useCallback((e) => {
+    const data = new FormData(e.currentTarget)
+    const message = data.get('message') as string | undefined
+    setHasMessage(!!message)
+  }, [])
+
+  const handleFormClick = useCallback(() => {
+    if (textAreaInputRef.current) {
+      textAreaInputRef.current.focus()
+    }
+  }, [])
 
   const handleAbort = useCallback(() => {
     if (id) {
@@ -412,7 +425,8 @@ export function ChatWindow({ id }: { id?: string }) {
 
         <form
           className="relative w-full overflow-hidden rounded-md border border-input"
-          onSubmit={handleMessage}
+          onSubmit={handleFormSubmit}
+          onChange={handleFormChange}
           ref={formRef}
         >
           <Textarea
@@ -426,7 +440,10 @@ export function ChatWindow({ id }: { id?: string }) {
             spellCheck={false}
             disabled={isFormDisabled}
           />
-          <div className="flex items-center justify-end gap-1 p-2">
+          <div
+            className="flex cursor-text items-center justify-end gap-1 p-2"
+            onClick={handleFormClick}
+          >
             {messages.length === 0 && (
               <Button
                 variant="iconButton"
@@ -443,7 +460,7 @@ export function ChatWindow({ id }: { id?: string }) {
               size="sm"
               className="group hover:bg-transparent"
               type="submit"
-              disabled={isFormDisabled}
+              disabled={isFormDisabled || !hasMessage}
             >
               Submit
             </Button>

--- a/src/renderer/components/chat-window.tsx
+++ b/src/renderer/components/chat-window.tsx
@@ -7,6 +7,7 @@ import {
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Textarea from 'react-textarea-autosize'
 import { useValue } from 'signia-react'
+import { toast } from 'sonner'
 
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
@@ -106,10 +107,13 @@ export function ChatWindow({ id }: { id?: string }) {
 
       if (file.name.endsWith('.pdf')) {
         setRunningEmbeddings(true)
+
         await transformersManager.embedDocument(file.path)
         await filesManager.loadFiles()
         historyManager.changeThreadFilePath(id, file.path)
+
         setRunningEmbeddings(false)
+        toast.success(`Embeddings generated for ${file.name}`)
       } else if (
         file.name.endsWith('.png') ||
         file.name.endsWith('.jpg') ||
@@ -213,19 +217,21 @@ export function ChatWindow({ id }: { id?: string }) {
     return undefined
   }, [currentThreadFilePath, selectedFile])
 
+  // Side effect for focusing textarea
   useEffect(() => {
-    if (id && !isCurrentThreadGenerating && textAreaInputRef.current) {
+    if (id && textAreaInputRef.current) {
       textAreaInputRef.current.focus()
     }
-  }, [isCurrentThreadGenerating, id])
+  }, [id])
 
+  // Side effect for scrolling to bottom
   useEffect(() => {
     if (id) {
       scrollToBottom('auto', true)
     }
   }, [id, messages, scrollToBottom])
 
-  // Unselect file when switching threads
+  // Side effect for resetting state when switching threads
   useEffect(() => {
     if (id) {
       setSelectedFile(null)

--- a/src/renderer/components/chat-window.tsx
+++ b/src/renderer/components/chat-window.tsx
@@ -4,7 +4,14 @@ import {
   LucideStopCircle,
   LucideTrash2,
 } from 'lucide-react'
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import Textarea from 'react-textarea-autosize'
 import { useValue } from 'signia-react'
 import { toast } from 'sonner'
@@ -80,6 +87,7 @@ export function ChatWindow({ id }: { id?: string }) {
 
   const [userScrolled, setUserScrolled] = useState(false)
   const [runningEmbeddings, setRunningEmbeddings] = useState(false)
+  const [shouldRefocusTextarea, setShouldRefocusTextarea] = useState(false)
 
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
   const [base64Image, setBase64Image] = useState<string | null>(null)
@@ -114,6 +122,9 @@ export function ChatWindow({ id }: { id?: string }) {
 
         setRunningEmbeddings(false)
         toast.success(`Embeddings generated for ${file.name}`)
+
+        // Rely on useState to refocus the textarea
+        setShouldRefocusTextarea(true)
       } else if (
         file.name.endsWith('.png') ||
         file.name.endsWith('.jpg') ||
@@ -217,11 +228,18 @@ export function ChatWindow({ id }: { id?: string }) {
     return undefined
   }, [currentThreadFilePath, selectedFile])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (id && !isCurrentThreadGenerating && textAreaInputRef.current) {
       textAreaInputRef.current.focus()
     }
   }, [isCurrentThreadGenerating, id])
+
+  useLayoutEffect(() => {
+    if (shouldRefocusTextarea && textAreaInputRef.current) {
+      textAreaInputRef.current.focus()
+      setShouldRefocusTextarea(false)
+    }
+  }, [shouldRefocusTextarea])
 
   useEffect(() => {
     if (id) {

--- a/src/renderer/components/chat-window.tsx
+++ b/src/renderer/components/chat-window.tsx
@@ -245,14 +245,11 @@ export function ChatWindow({ id }: { id?: string }) {
     if (id && !isCurrentThreadGenerating && textAreaInputRef.current) {
       textAreaInputRef.current.focus()
     }
-  }, [isCurrentThreadGenerating, id])
-
-  useLayoutEffect(() => {
     if (shouldRefocusTextarea && textAreaInputRef.current) {
       textAreaInputRef.current.focus()
       setShouldRefocusTextarea(false)
     }
-  }, [shouldRefocusTextarea])
+  }, [isCurrentThreadGenerating, id, shouldRefocusTextarea])
 
   useEffect(() => {
     if (id) {

--- a/src/renderer/components/chat-window.tsx
+++ b/src/renderer/components/chat-window.tsx
@@ -85,8 +85,8 @@ export function ChatWindow({ id }: { id?: string }) {
   const [base64Image, setBase64Image] = useState<string | null>(null)
 
   const fileInputRef = useRef<HTMLInputElement>(null)
-  const textAreaInputRef = React.useRef<HTMLTextAreaElement>(null)
-  const scrollAreaRef = React.useRef<HTMLDivElement>(null)
+  const textAreaInputRef = useRef<HTMLTextAreaElement>(null)
+  const scrollAreaRef = useRef<HTMLDivElement>(null)
 
   const supportsImages = modelData?.capabilities?.includes('images') ?? false
 
@@ -217,21 +217,18 @@ export function ChatWindow({ id }: { id?: string }) {
     return undefined
   }, [currentThreadFilePath, selectedFile])
 
-  // Side effect for focusing textarea
   useEffect(() => {
-    if (id && textAreaInputRef.current) {
+    if (id && !isCurrentThreadGenerating && textAreaInputRef.current) {
       textAreaInputRef.current.focus()
     }
-  }, [id])
+  }, [isCurrentThreadGenerating, id])
 
-  // Side effect for scrolling to bottom
   useEffect(() => {
     if (id) {
       scrollToBottom('auto', true)
     }
   }, [id, messages, scrollToBottom])
 
-  // Side effect for resetting state when switching threads
   useEffect(() => {
     if (id) {
       setSelectedFile(null)
@@ -246,7 +243,7 @@ export function ChatWindow({ id }: { id?: string }) {
     runningEmbeddings ||
     (fileName !== undefined &&
       !base64Image &&
-      filesManager.isFileArchived(fileName!))
+      filesManager.isFileNotArchived(fileName!))
 
   return (
     // 36px - titlebar height
@@ -330,9 +327,8 @@ export function ChatWindow({ id }: { id?: string }) {
               >
                 {fileName}
               </span>
-              {filesManager.isFileArchived(fileName!) && !runningEmbeddings && (
-                <span className="ml-1">(removed)</span>
-              )}
+              {filesManager.isFileNotArchived(fileName!) &&
+                !runningEmbeddings && <span className="ml-1">(removed)</span>}
             </div>
           ) : null}
 

--- a/src/renderer/components/chat-window.tsx
+++ b/src/renderer/components/chat-window.tsx
@@ -271,7 +271,7 @@ export function ChatWindow({ id }: { id?: string }) {
     runningEmbeddings ||
     (fileName !== undefined &&
       !base64Image &&
-      filesManager.isFileNotArchived(fileName!))
+      filesManager.isFileArchived(fileName!))
 
   return (
     // 36px - titlebar height
@@ -355,8 +355,9 @@ export function ChatWindow({ id }: { id?: string }) {
               >
                 {fileName}
               </span>
-              {filesManager.isFileNotArchived(fileName!) &&
-                !runningEmbeddings && <span className="ml-1">(removed)</span>}
+              {filesManager.isFileArchived(fileName!) && !runningEmbeddings && (
+                <span className="ml-1">(removed)</span>
+              )}
             </div>
           ) : null}
 

--- a/src/renderer/providers/chat/manager.ts
+++ b/src/renderer/providers/chat/manager.ts
@@ -1,6 +1,7 @@
 import { createContext, useContext } from 'react'
 import { atom, computed } from 'signia'
 import { useValue } from 'signia-react'
+import { toast } from 'sonner'
 
 import { Message } from '@/providers/chat/types'
 import { HistoryManager, useThread } from '@/providers/history/manager'
@@ -125,6 +126,8 @@ export class ChatManager {
     selectedFile?: string
     addToHistory?: boolean
   }) {
+    toast.dismiss()
+
     if (threadID) {
       this.setRunningPrompt(threadID, true)
     }
@@ -292,8 +295,7 @@ export class ChatManager {
       }
     } catch (e) {
       const error = e as Error
-      // eslint-disable-next-line no-console
-      console.error('Error sending message:', error)
+      toast.error(error.message)
     } finally {
       if (threadID) {
         this.setRunningPrompt(threadID, false)
@@ -308,6 +310,8 @@ export class ChatManager {
     threadID: string
     messageID: string
   }) {
+    toast.dismiss()
+
     if (threadID) {
       this.setRunningPrompt(threadID, true)
     }
@@ -343,8 +347,7 @@ export class ChatManager {
       })
     } catch (e) {
       const error = e as Error
-      // eslint-disable-next-line no-console
-      console.error('Error regenerating message:', error)
+      toast.error(error.message)
     } finally {
       if (threadID) {
         this.setRunningPrompt(threadID, false)
@@ -579,6 +582,13 @@ export function useCurrentSystemPrompt() {
     () => chatManager.state.currentSystemPrompt,
     [chatManager],
   )
+}
+
+export function useRunningPrompts() {
+  const chatManager = useChatManager()
+  return useValue('useRunningPrompts', () => chatManager.state.runningPrompts, [
+    chatManager,
+  ])
 }
 
 export function useIsCurrentThreadGenerating(threadID?: string) {

--- a/src/renderer/providers/files/manager.ts
+++ b/src/renderer/providers/files/manager.ts
@@ -51,8 +51,8 @@ export class FilesManager {
     return this.state.embeddingsIndexes
   }
 
-  isFileArchived(filename: string) {
-    return this.state.embeddingsMeta.some((entry) => entry.name === filename)
+  isFileNotArchived(filename: string) {
+    return !this.state.embeddingsMeta.some((entry) => entry.name === filename)
   }
 }
 

--- a/src/renderer/providers/files/manager.ts
+++ b/src/renderer/providers/files/manager.ts
@@ -51,7 +51,7 @@ export class FilesManager {
     return this.state.embeddingsIndexes
   }
 
-  isFileNotArchived(filename: string) {
+  isFileArchived(filename: string) {
     return !this.state.embeddingsMeta.some((entry) => entry.name === filename)
   }
 }


### PR DESCRIPTION
- [x] surface silent prompt errors via toast
- [x] dereference win for "Object has been destroyed" https://github.com/dynaboard/ai-studio/pull/70/commits/6610ac6010f767075ac53629ea39ea55406cc9a6 https://github.com/reZach/i18next-electron-fs-backend/issues/1#issuecomment-579058481
- [x] delete thread without confirm dialog if it's empty
- [x] increase the clickarea of form textarea


https://github.com/dynaboard/ai-studio/assets/1021101/dc124da5-ff72-4cc4-a8b4-9190d88fcc92